### PR TITLE
add unescapehtml option to prevent json engine escpae some html characte...

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -29,8 +29,9 @@ type XML struct {
 // JSON built-in renderer.
 type JSON struct {
 	Head
-	Indent bool
-	Prefix []byte
+	Indent       bool
+	UnEsacpeHTML bool
+	Prefix       []byte
 }
 
 // JSONP built-in renderer.
@@ -83,6 +84,13 @@ func (j JSON) Render(w http.ResponseWriter, v interface{}) error {
 	}
 	if err != nil {
 		return err
+	}
+
+	// unescape html
+	if j.UnEsacpeHTML {
+		result = bytes.Replace(result, []byte("\\u003c"), []byte("<"), -1)
+		result = bytes.Replace(result, []byte("\\u003e"), []byte(">"), -1)
+		result = bytes.Replace(result, []byte("\\u0026"), []byte("&"), -1)
 	}
 
 	// JSON marshaled fine, write out the result.

--- a/engine.go
+++ b/engine.go
@@ -30,7 +30,7 @@ type XML struct {
 type JSON struct {
 	Head
 	Indent       bool
-	UnEsacpeHTML bool
+	UnEscapeHTML bool
 	Prefix       []byte
 }
 
@@ -87,7 +87,7 @@ func (j JSON) Render(w http.ResponseWriter, v interface{}) error {
 	}
 
 	// unescape html
-	if j.UnEsacpeHTML {
+	if j.UnEscapeHTML {
 		result = bytes.Replace(result, []byte("\\u003c"), []byte("<"), -1)
 		result = bytes.Replace(result, []byte("\\u003e"), []byte(">"), -1)
 		result = bytes.Replace(result, []byte("\\u0026"), []byte("&"), -1)

--- a/render.go
+++ b/render.go
@@ -76,6 +76,8 @@ type Options struct {
 	HTMLContentType string
 	// If IsDevelopment is set to true, this will recompile the templates on every request. Default if false.
 	IsDevelopment bool
+	// unescape html utf-8 characters(&<>) to orignal
+	UnEsacpeHTML bool
 }
 
 // HTMLOptions is a struct for overriding some rendering Options for specific HTML call.
@@ -205,9 +207,10 @@ func (r *Render) JSON(w http.ResponseWriter, status int, v interface{}) {
 	}
 
 	j := JSON{
-		Head:   head,
-		Indent: r.opt.IndentJSON,
-		Prefix: r.opt.PrefixJSON,
+		Head:         head,
+		Indent:       r.opt.IndentJSON,
+		Prefix:       r.opt.PrefixJSON,
+		UnEsacpeHTML: r.opt.UnEsacpeHTML,
 	}
 
 	r.Render(w, j, v)

--- a/render.go
+++ b/render.go
@@ -77,7 +77,7 @@ type Options struct {
 	// If IsDevelopment is set to true, this will recompile the templates on every request. Default if false.
 	IsDevelopment bool
 	// unescape html utf-8 characters(&<>) to orignal
-	UnEsacpeHTML bool
+	UnEscapeHTML bool
 }
 
 // HTMLOptions is a struct for overriding some rendering Options for specific HTML call.
@@ -210,7 +210,7 @@ func (r *Render) JSON(w http.ResponseWriter, status int, v interface{}) {
 		Head:         head,
 		Indent:       r.opt.IndentJSON,
 		Prefix:       r.opt.PrefixJSON,
-		UnEsacpeHTML: r.opt.UnEsacpeHTML,
+		UnEscapeHTML: r.opt.UnEscapeHTML,
 	}
 
 	r.Render(w, j, v)

--- a/render_test.go
+++ b/render_test.go
@@ -113,6 +113,23 @@ func TestRenderJSONWithError(t *testing.T) {
 	expect(t, res.Code, 500)
 }
 
+func TestRenderJSONWithUnEscapeHTML(t *testing.T) {
+	render := New(Options{
+		UnEscapeHTML: true,
+	})
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		render.JSON(w, http.StatusOK, Greeting{"<span>test&test</span>", "<div>test&test</div>"})
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/foo", nil)
+	h.ServeHTTP(res, req)
+
+	output := res.Body.String()
+	//fmt.Println(str)
+	expect(t, output, `{"one":"<span>test&test</span>","two":"<div>test&test</div>"}`)
+}
+
 func TestRenderJSONP(t *testing.T) {
 	render := New()
 


### PR DESCRIPTION
i add a option to prevent golang default json engine to escape some html characters, some case we need to render origin html characters, no need to escape this. thanks.