### PR TITLE
Add support for go-bindata

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Render comes with a variety of configuration options _(Note: these are not the d
 // ...
 r := render.New(render.Options{
     Directory: "templates", // Specify what path to load the templates from.
+    Asset: func(name string) ([]byte, error) { // Load from an Asset function instead of file.
+      return []byte("template content"), nil
+    },
+    AssetNames: func() []string { // Return a list of asset names for the Asset function
+      return []string{"filename.tmpl"}
+    },
     Layout: "layout", // Specify a layout template. Layouts can call {{ yield }} to render the current template.
     Extensions: []string{".tmpl", ".html"}, // Specify extensions to load for templates.
     Funcs: []template.FuncMap{AppHelpers}, // Specify helper function maps for templates to access.
@@ -98,6 +104,8 @@ r := render.New()
 
 r := render.New(render.Options{
     Directory: "templates",
+    Asset: nil,
+    AssetNames: nil,
     Layout: "",
     Extensions: []string{".tmpl"},
     Funcs: []template.FuncMap{},
@@ -133,6 +141,9 @@ admin/index
 admin/edit
 home
 ~~~
+
+You can also load templates from memory by providing the Asset and AssetNames options,
+e.g. when generating an asset file using [go-bindata][https://github.com/jteeuwen/go-bindata].
 
 ### Layouts
 Render provides a `yield` function for layouts to access:

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ home
 ~~~
 
 You can also load templates from memory by providing the Asset and AssetNames options,
-e.g. when generating an asset file using [go-bindata][https://github.com/jteeuwen/go-bindata].
+e.g. when generating an asset file using [go-bindata](https://github.com/jteeuwen/go-bindata).
 
 ### Layouts
 Render provides a `yield` function for layouts to access:

--- a/render.go
+++ b/render.go
@@ -54,6 +54,10 @@ type Delims struct {
 type Options struct {
 	// Directory to load templates. Default is "templates".
 	Directory string
+	// Asset function to use in place of directory. Defaults to nil.
+	Asset func(name string) ([]byte, error)
+	// AssetNames function to use in place of directory. Defaults to nil.
+	AssetNames func() []string
 	// Layout template name. Will not render a layout if blank (""). Defaults to blank ("").
 	Layout string
 	// Extensions to parse template files from. Defaults to [".tmpl"].
@@ -131,6 +135,14 @@ func (r *Render) prepareOptions() {
 }
 
 func (r *Render) compileTemplates() {
+	if r.opt.Asset == nil || r.opt.AssetNames == nil {
+		r.compileTemplatesFromDir()
+		return
+	}
+	r.compileTemplatesFromAsset()
+}
+
+func (r *Render) compileTemplatesFromDir() {
 	dir := r.opt.Directory
 	r.templates = template.New(dir)
 	r.templates.Delims(r.opt.Delims.Left, r.opt.Delims.Right)
@@ -171,6 +183,50 @@ func (r *Render) compileTemplates() {
 
 		return nil
 	})
+}
+
+func (r *Render) compileTemplatesFromAsset() {
+	dir := r.opt.Directory
+	r.templates = template.New(dir)
+	r.templates.Delims(r.opt.Delims.Left, r.opt.Delims.Right)
+
+	for _, path := range r.opt.AssetNames() {
+		if !strings.HasPrefix(path, dir) {
+			continue
+		}
+
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			panic(err)
+		}
+
+		ext := ""
+		if strings.Index(rel, ".") != -1 {
+			ext = "." + strings.Join(strings.Split(rel, ".")[1:], ".")
+		}
+
+		for _, extension := range r.opt.Extensions {
+			if ext == extension {
+
+				buf, err := r.opt.Asset(path)
+				if err != nil {
+					panic(err)
+				}
+
+				name := (rel[0 : len(rel)-len(ext)])
+				tmpl := r.templates.New(filepath.ToSlash(name))
+
+				// Add our funcmaps.
+				for _, funcs := range r.opt.Funcs {
+					tmpl.Funcs(funcs)
+				}
+
+				// Break out if this parsing fails. We don't want any silent server starts.
+				template.Must(tmpl.Funcs(helperFuncs).Parse(string(buf)))
+				break
+			}
+		}
+	}
 }
 
 // Render is the generic function called by XML, JSON, Data, HTML, and can be called by custom implementations.


### PR DESCRIPTION
Adds support for [go-bindata](https://github.com/jteeuwen/go-bindata) via the `Asset` and `AssetNames` options.