### PR TITLE
Added a buffer pool for writing HTML templates to.

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -1,0 +1,41 @@
+package render
+
+import "bytes"
+
+// bufPool represents a reusable buffer pool for executing templates into.
+var bufPool *BufferPool
+
+// BufferPool implements a pool of bytes.Buffers in the form of a bounded channel.
+// Pulled from the github.com/oxtoacart/bpool package (Apache licensed).
+type BufferPool struct {
+	c chan *bytes.Buffer
+}
+
+// NewBufferPool creates a new BufferPool bounded to the given size.
+func NewBufferPool(size int) (bp *BufferPool) {
+	return &BufferPool{
+		c: make(chan *bytes.Buffer, size),
+	}
+}
+
+// Get gets a Buffer from the BufferPool, or creates a new one if none are
+// available in the pool.
+func (bp *BufferPool) Get() (b *bytes.Buffer) {
+	select {
+	case b = <-bp.c:
+	// reuse existing buffer
+	default:
+		// create new buffer
+		b = bytes.NewBuffer([]byte{})
+	}
+	return
+}
+
+// Put returns the given Buffer to the BufferPool.
+func (bp *BufferPool) Put(b *bytes.Buffer) {
+	b.Reset()
+	select {
+	case bp.c <- b:
+	default: // Discard the buffer if the pool is full.
+	}
+}

--- a/engine.go
+++ b/engine.go
@@ -169,13 +169,17 @@ func (x XML) Render(w http.ResponseWriter, v interface{}) error {
 
 // Render a HTML response.
 func (h HTML) Render(w http.ResponseWriter, binding interface{}) error {
-	out := new(bytes.Buffer)
+	// Retrieve a buffer from the pool to write to.
+	out := bufPool.Get()
 	err := h.Templates.ExecuteTemplate(out, h.Name, binding)
 	if err != nil {
 		return err
 	}
 
 	h.Head.Write(w)
-	w.Write(out.Bytes())
+	out.WriteTo(w)
+
+	// Return the buffer to the pool.
+	bufPool.Put(out)
 	return nil
 }

--- a/render.go
+++ b/render.go
@@ -117,6 +117,11 @@ func New(options ...Options) *Render {
 	r.prepareOptions()
 	r.compileTemplates()
 
+	// Create a new buffer pool for writing templates into.
+	if bufPool == nil {
+		bufPool = NewBufferPool(64)
+	}
+
 	return &r
 }
 


### PR DESCRIPTION
Replaces the temporary buffers discarded per-request.
Based on the code from https://github.com/oxtoacart/bpool

Refer to https://github.com/unrolled/render/issues/27