### PR TITLE
Add .gitattributes to ensure line endings are always LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
The tests expect LF line endings ('\n'), so we need to make sure that the
LF line endings are retained for this repository, even on Windows.

resolves #37