### PR TITLE
Undefined block templates

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text eol=lf

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ r := render.New(render.Options{
     IsDevelopment: true, // Render will now recompile the templates on every HTML response.
     UnEscapeHTML: true, // Replace ensure '&<>' are output correctly (JSON only).
     StreamingJSON: true, // Streams the JSON response via json.Encoder.
+    RequireBlocks: true, // Return an error if a template is missing a block used in a layout.
 })
 // ...
 ~~~
@@ -126,6 +127,7 @@ r := render.New(render.Options{
     IsDevelopment: false,
     UnEscapeHTML: false,
     StreamingJSON: false,
+    RequireBlocks: false,
 })
 ~~~
 
@@ -200,6 +202,23 @@ r := render.New(render.Options{
   </body>
 </html>
 ~~~
+
+Blocks are defined by individual templates as seen below. The block template's
+name needs to be defined as "{block name}-{template name}".
+~~~ html
+<!-- templates/home.tmpl -->
+{{ define "header-home" }}
+<h1>Home</h1>
+{{ end }}
+
+{{ define "footer-home"}}
+<p>The End</p>
+{{ end }}
+~~~
+
+By default, the template is not required to define all blocks referenced in the
+layout. If you want an error to be returned when a template does not define a
+block, set `Options.RequireBlocks = true`.
 
 ### Character Encodings
 Render will automatically set the proper Content-Type header based on which function you call. See below for an example of what the default settings would output (note that UTF-8 is the default, and binary data does not output the charset):

--- a/fixtures/blocks/content-partial.tmpl
+++ b/fixtures/blocks/content-partial.tmpl
@@ -1,0 +1,1 @@
+{{define "after-content-partial"}}after {{ . }}{{end}}

--- a/render.go
+++ b/render.go
@@ -89,6 +89,8 @@ type Options struct {
 	UnEscapeHTML bool
 	// Streams JSON responses instead of marshalling prior to sending. Default is false.
 	StreamingJSON bool
+	// Require that all blocks executed in the layout are implemented in all templates using the layout. Default is false.
+	RequireBlocks bool
 }
 
 // HTMLOptions is a struct for overriding some rendering Options for specific HTML call.
@@ -273,9 +275,13 @@ func (r *Render) addLayoutFuncs(name string, binding interface{}) {
 			return name, nil
 		},
 		"block": func(blockName string) (template.HTML, error) {
-			buf, err := r.execute(fmt.Sprintf("%s-%s", blockName, name), binding)
-			// Return safe HTML here since we are rendering our own template.
-			return template.HTML(buf.String()), err
+			fullBlockName := fmt.Sprintf("%s-%s", blockName, name)
+			if r.opt.RequireBlocks || r.TemplateLookup(fullBlockName) != nil {
+				buf, err := r.execute(fullBlockName, binding)
+				// Return safe HTML here since we are rendering our own template.
+				return template.HTML(buf.String()), err
+			}
+			return "", nil
 		},
 	}
 	if tpl := r.templates.Lookup(name); tpl != nil {

--- a/render_html_test.go
+++ b/render_html_test.go
@@ -141,6 +141,48 @@ func TestRenderBlock(t *testing.T) {
 	expect(t, res.Body.String(), "before gophers\n<h1>during</h1>\nafter gophers\n")
 }
 
+func TestRenderBlockRequireBlocksOff(t *testing.T) {
+	render := New(Options{
+		Directory:     "fixtures/blocks",
+		Layout:        "layout",
+		RequireBlocks: false,
+	})
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		render.HTML(w, http.StatusOK, "content-partial", "gophers")
+	})
+
+	res := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/foo", nil)
+	if err != nil {
+		t.Fatalf("couldn't create a request. err = %s", err)
+	}
+	h.ServeHTTP(res, req)
+
+	expect(t, res.Body.String(), "\n<h1>during</h1>\nafter gophers\n")
+}
+
+func TestRenderBlockRequireBlocksOn(t *testing.T) {
+	render := New(Options{
+		Directory:     "fixtures/blocks",
+		Layout:        "layout",
+		RequireBlocks: true,
+	})
+
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		render.HTML(w, http.StatusOK, "content-partial", "gophers")
+	})
+
+	res := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/foo", nil)
+	if err != nil {
+		t.Fatalf("couldn't create a request. err = %s", err)
+	}
+	h.ServeHTTP(res, req)
+
+	expect(t, res.Body.String(), "template: layout:1:3: executing \"layout\" at <block \"before\">: error calling block: html/template: \"before-content-partial\" is undefined\n")
+}
+
 func TestHTMLLayoutCurrent(t *testing.T) {
 	render := New(Options{
 		Directory: "fixtures/basic",


### PR DESCRIPTION
This pull request addresses the "undefined blocks" portion of the discussion in issue #36. The changes here make defining blocks optional, unless you set `Options.RequireBlocks = true`.