### PR TITLE
Return errors from rendering methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ r := render.New(render.Options{
     UnEscapeHTML: true, // Replace ensure '&<>' are output correctly (JSON only).
     StreamingJSON: true, // Streams the JSON response via json.Encoder.
     RequireBlocks: true, // Return an error if a template is missing a block used in a layout.
+    DisableHTTPErrorRendering: true, // Disables automatic rendering of http.StatusInternalServerError when an error occurs.
 })
 // ...
 ~~~
@@ -128,6 +129,7 @@ r := render.New(render.Options{
     UnEscapeHTML: false,
     StreamingJSON: false,
     RequireBlocks: false,
+    DisableHTTPErrorRendering: false,
 })
 ~~~
 
@@ -328,6 +330,26 @@ func main() {
     })
 
     http.ListenAndServe("127.0.0.1:3000", mux)
+}
+~~~
+
+### Error Handling
+
+The rendering functions return any errors from the rendering engine.
+By default, they will also write the error to the HTTP response and set the status code to 500. You can disable
+this behavior so that you can handle errors yourself by setting
+`Options.DisableHTTPErrorRendering: true`.
+
+~~~go
+r := render.New(render.Options{
+  DisableHTTPErrorRendering: true,
+})
+
+//...
+
+err := r.HTML(w, http.StatusOK, "example", nil)
+if err != nil{
+  http.Redirect(w, r, "/my-custom-500", http.StatusFound)
 }
 ~~~
 

--- a/render.go
+++ b/render.go
@@ -91,6 +91,8 @@ type Options struct {
 	StreamingJSON bool
 	// Require that all blocks executed in the layout are implemented in all templates using the layout. Default is false.
 	RequireBlocks bool
+	// Disables automatic rendering of http.StatusInternalServerError when an error occurs. Default is false.
+	DisableHTTPErrorRendering bool
 }
 
 // HTMLOptions is a struct for overriding some rendering Options for specific HTML call.
@@ -300,15 +302,16 @@ func (r *Render) prepareHTMLOptions(htmlOpt []HTMLOptions) HTMLOptions {
 }
 
 // Render is the generic function called by XML, JSON, Data, HTML, and can be called by custom implementations.
-func (r *Render) Render(w http.ResponseWriter, e Engine, data interface{}) {
+func (r *Render) Render(w http.ResponseWriter, e Engine, data interface{}) error {
 	err := e.Render(w, data)
-	if err != nil {
+	if err != nil && !r.opt.DisableHTTPErrorRendering {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
+	return err
 }
 
 // Data writes out the raw bytes as binary data.
-func (r *Render) Data(w http.ResponseWriter, status int, v []byte) {
+func (r *Render) Data(w http.ResponseWriter, status int, v []byte) error {
 	head := Head{
 		ContentType: ContentBinary,
 		Status:      status,
@@ -318,11 +321,11 @@ func (r *Render) Data(w http.ResponseWriter, status int, v []byte) {
 		Head: head,
 	}
 
-	r.Render(w, d, v)
+	return r.Render(w, d, v)
 }
 
 // HTML builds up the response from the specified template and bindings.
-func (r *Render) HTML(w http.ResponseWriter, status int, name string, binding interface{}, htmlOpt ...HTMLOptions) {
+func (r *Render) HTML(w http.ResponseWriter, status int, name string, binding interface{}, htmlOpt ...HTMLOptions) error {
 	// If we are in development mode, recompile the templates on every HTML request.
 	if r.opt.IsDevelopment {
 		r.compileTemplates()
@@ -346,11 +349,11 @@ func (r *Render) HTML(w http.ResponseWriter, status int, name string, binding in
 		Templates: r.templates,
 	}
 
-	r.Render(w, h, binding)
+	return r.Render(w, h, binding)
 }
 
 // JSON marshals the given interface object and writes the JSON response.
-func (r *Render) JSON(w http.ResponseWriter, status int, v interface{}) {
+func (r *Render) JSON(w http.ResponseWriter, status int, v interface{}) error {
 	head := Head{
 		ContentType: ContentJSON + r.compiledCharset,
 		Status:      status,
@@ -364,11 +367,11 @@ func (r *Render) JSON(w http.ResponseWriter, status int, v interface{}) {
 		StreamingJSON: r.opt.StreamingJSON,
 	}
 
-	r.Render(w, j, v)
+	return r.Render(w, j, v)
 }
 
 // JSONP marshals the given interface object and writes the JSON response.
-func (r *Render) JSONP(w http.ResponseWriter, status int, callback string, v interface{}) {
+func (r *Render) JSONP(w http.ResponseWriter, status int, callback string, v interface{}) error {
 	head := Head{
 		ContentType: ContentJSONP + r.compiledCharset,
 		Status:      status,
@@ -380,11 +383,11 @@ func (r *Render) JSONP(w http.ResponseWriter, status int, callback string, v int
 		Callback: callback,
 	}
 
-	r.Render(w, j, v)
+	return r.Render(w, j, v)
 }
 
 // Text writes out a string as plain text.
-func (r *Render) Text(w http.ResponseWriter, status int, v string) {
+func (r *Render) Text(w http.ResponseWriter, status int, v string) error {
 	head := Head{
 		ContentType: ContentText + r.compiledCharset,
 		Status:      status,
@@ -394,11 +397,11 @@ func (r *Render) Text(w http.ResponseWriter, status int, v string) {
 		Head: head,
 	}
 
-	r.Render(w, t, v)
+	return r.Render(w, t, v)
 }
 
 // XML marshals the given interface object and writes the XML response.
-func (r *Render) XML(w http.ResponseWriter, status int, v interface{}) {
+func (r *Render) XML(w http.ResponseWriter, status int, v interface{}) error {
 	head := Head{
 		ContentType: ContentXML + r.compiledCharset,
 		Status:      status,
@@ -410,5 +413,5 @@ func (r *Render) XML(w http.ResponseWriter, status int, v interface{}) {
 		Prefix: r.opt.PrefixXML,
 	}
 
-	r.Render(w, x, v)
+	return r.Render(w, x, v)
 }

--- a/render_data_test.go
+++ b/render_data_test.go
@@ -11,14 +11,16 @@ func TestDataBinaryBasic(t *testing.T) {
 	// nothing here to configure
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.Data(w, 299, []byte("hello there"))
+		err = render.Data(w, 299, []byte("hello there"))
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNil(t, err)
 	expect(t, res.Code, 299)
 	expect(t, res.Header().Get(ContentType), ContentBinary)
 	expect(t, res.Body.String(), "hello there")
@@ -29,15 +31,17 @@ func TestDataCustomMimeType(t *testing.T) {
 	// nothing here to configure
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set(ContentType, "image/jpeg")
-		render.Data(w, http.StatusOK, []byte("..jpeg data.."))
+		err = render.Data(w, http.StatusOK, []byte("..jpeg data.."))
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNil(t, err)
 	expect(t, res.Code, http.StatusOK)
 	expect(t, res.Header().Get(ContentType), "image/jpeg")
 	expect(t, res.Body.String(), "..jpeg data..")

--- a/render_html_test.go
+++ b/render_html_test.go
@@ -347,9 +347,9 @@ func TestHTMLNoRace(t *testing.T) {
 		Directory: "fixtures/basic",
 	})
 
-	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err = render.HTML(w, http.StatusOK, "hello", "gophers")
+		err := render.HTML(w, http.StatusOK, "hello", "gophers")
+		expectNil(t, err)
 	})
 
 	done := make(chan bool)
@@ -359,7 +359,6 @@ func TestHTMLNoRace(t *testing.T) {
 
 		h.ServeHTTP(res, req)
 
-		expectNil(t, err)
 		expect(t, res.Code, 200)
 		expect(t, res.Header().Get(ContentType), ContentHTML+"; charset=UTF-8")
 		// ContentLength should be deferred to the ResponseWriter and not Render

--- a/render_html_test.go
+++ b/render_html_test.go
@@ -13,16 +13,38 @@ func TestHTMLBad(t *testing.T) {
 		Directory: "fixtures/basic",
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.HTML(w, http.StatusOK, "nope", nil)
+		err = render.HTML(w, http.StatusOK, "nope", nil)
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNotNil(t, err)
 	expect(t, res.Code, 500)
 	expect(t, res.Body.String(), "html/template: \"nope\" is undefined\n")
+}
+
+func TestHTMLBadDisableHTTPErrorRendering(t *testing.T) {
+	render := New(Options{
+		Directory:                 "fixtures/basic",
+		DisableHTTPErrorRendering: true,
+	})
+
+	var err error
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err = render.HTML(w, http.StatusOK, "nope", nil)
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/foo", nil)
+	h.ServeHTTP(res, req)
+
+	expectNotNil(t, err)
+	expect(t, res.Code, 200)
+	expect(t, res.Body.String(), "")
 }
 
 func TestHTMLBasic(t *testing.T) {
@@ -30,14 +52,16 @@ func TestHTMLBasic(t *testing.T) {
 		Directory: "fixtures/basic",
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.HTML(w, http.StatusOK, "hello", "gophers")
+		err = render.HTML(w, http.StatusOK, "hello", "gophers")
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNil(t, err)
 	expect(t, res.Code, 200)
 	expect(t, res.Header().Get(ContentType), ContentHTML+"; charset=UTF-8")
 	expect(t, res.Body.String(), "<h1>Hello gophers</h1>\n")
@@ -49,14 +73,16 @@ func TestHTMLXHTML(t *testing.T) {
 		HTMLContentType: ContentXHTML,
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.HTML(w, http.StatusOK, "hello", "gophers")
+		err = render.HTML(w, http.StatusOK, "hello", "gophers")
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNil(t, err)
 	expect(t, res.Code, 200)
 	expect(t, res.Header().Get(ContentType), ContentXHTML+"; charset=UTF-8")
 	expect(t, res.Body.String(), "<h1>Hello gophers</h1>\n")
@@ -68,14 +94,16 @@ func TestHTMLExtensions(t *testing.T) {
 		Extensions: []string{".tmpl", ".html"},
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.HTML(w, http.StatusOK, "hypertext", nil)
+		err = render.HTML(w, http.StatusOK, "hypertext", nil)
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNil(t, err)
 	expect(t, res.Code, 200)
 	expect(t, res.Header().Get(ContentType), ContentHTML+"; charset=UTF-8")
 	expect(t, res.Body.String(), "Hypertext!\n")
@@ -93,14 +121,16 @@ func TestHTMLFuncs(t *testing.T) {
 		},
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.HTML(w, http.StatusOK, "index", "gophers")
+		err = render.HTML(w, http.StatusOK, "index", "gophers")
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNil(t, err)
 	expect(t, res.Body.String(), "My custom function\n")
 }
 
@@ -110,14 +140,16 @@ func TestRenderLayout(t *testing.T) {
 		Layout:    "layout",
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.HTML(w, http.StatusOK, "content", "gophers")
+		err = render.HTML(w, http.StatusOK, "content", "gophers")
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNil(t, err)
 	expect(t, res.Body.String(), "head\n<h1>gophers</h1>\n\nfoot\n")
 }
 
@@ -127,8 +159,9 @@ func TestRenderBlock(t *testing.T) {
 		Layout:    "layout",
 	})
 
+	var renErr error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.HTML(w, http.StatusOK, "content", "gophers")
+		renErr = render.HTML(w, http.StatusOK, "content", "gophers")
 	})
 
 	res := httptest.NewRecorder()
@@ -138,6 +171,7 @@ func TestRenderBlock(t *testing.T) {
 	}
 	h.ServeHTTP(res, req)
 
+	expectNil(t, renErr)
 	expect(t, res.Body.String(), "before gophers\n<h1>during</h1>\nafter gophers\n")
 }
 
@@ -189,14 +223,16 @@ func TestHTMLLayoutCurrent(t *testing.T) {
 		Layout:    "current_layout",
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.HTML(w, http.StatusOK, "content", "gophers")
+		err = render.HTML(w, http.StatusOK, "content", "gophers")
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNil(t, err)
 	expect(t, res.Body.String(), "content head\n<h1>gophers</h1>\n\ncontent foot\n")
 }
 
@@ -205,14 +241,16 @@ func TestHTMLNested(t *testing.T) {
 		Directory: "fixtures/basic",
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.HTML(w, http.StatusOK, "admin/index", "gophers")
+		err = render.HTML(w, http.StatusOK, "admin/index", "gophers")
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNil(t, err)
 	expect(t, res.Code, 200)
 	expect(t, res.Header().Get(ContentType), ContentHTML+"; charset=UTF-8")
 	expect(t, res.Body.String(), "<h1>Admin gophers</h1>\n")
@@ -223,14 +261,16 @@ func TestHTMLBadPath(t *testing.T) {
 		Directory: "../../../../../../../../../../../../../../../../fixtures/basic",
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.HTML(w, http.StatusOK, "hello", "gophers")
+		err = render.HTML(w, http.StatusOK, "hello", "gophers")
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNotNil(t, err)
 	expect(t, res.Code, 500)
 }
 
@@ -240,14 +280,16 @@ func TestHTMLDelimiters(t *testing.T) {
 		Directory: "fixtures/basic",
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.HTML(w, http.StatusOK, "delims", "gophers")
+		err = render.HTML(w, http.StatusOK, "delims", "gophers")
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNil(t, err)
 	expect(t, res.Code, 200)
 	expect(t, res.Header().Get(ContentType), ContentHTML+"; charset=UTF-8")
 	expect(t, res.Body.String(), "<h1>Hello gophers</h1>")
@@ -258,14 +300,16 @@ func TestHTMLDefaultCharset(t *testing.T) {
 		Directory: "fixtures/basic",
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.HTML(w, http.StatusOK, "hello", "gophers")
+		err = render.HTML(w, http.StatusOK, "hello", "gophers")
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNil(t, err)
 	expect(t, res.Code, 200)
 	expect(t, res.Header().Get(ContentType), ContentHTML+"; charset=UTF-8")
 
@@ -280,8 +324,9 @@ func TestHTMLOverrideLayout(t *testing.T) {
 		Layout:    "layout",
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.HTML(w, http.StatusOK, "content", "gophers", HTMLOptions{
+		err = render.HTML(w, http.StatusOK, "content", "gophers", HTMLOptions{
 			Layout: "another_layout",
 		})
 	})
@@ -290,6 +335,7 @@ func TestHTMLOverrideLayout(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNil(t, err)
 	expect(t, res.Code, 200)
 	expect(t, res.Header().Get(ContentType), ContentHTML+"; charset=UTF-8")
 	expect(t, res.Body.String(), "another head\n<h1>gophers</h1>\n\nanother foot\n")
@@ -301,8 +347,9 @@ func TestHTMLNoRace(t *testing.T) {
 		Directory: "fixtures/basic",
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.HTML(w, http.StatusOK, "hello", "gophers")
+		err = render.HTML(w, http.StatusOK, "hello", "gophers")
 	})
 
 	done := make(chan bool)
@@ -312,6 +359,7 @@ func TestHTMLNoRace(t *testing.T) {
 
 		h.ServeHTTP(res, req)
 
+		expectNil(t, err)
 		expect(t, res.Code, 200)
 		expect(t, res.Header().Get(ContentType), ContentHTML+"; charset=UTF-8")
 		// ContentLength should be deferred to the ResponseWriter and not Render
@@ -343,8 +391,9 @@ func TestHTMLLoadFromAssets(t *testing.T) {
 		},
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.HTML(w, http.StatusOK, "test", "gophers", HTMLOptions{
+		err = render.HTML(w, http.StatusOK, "test", "gophers", HTMLOptions{
 			Layout: "layout",
 		})
 	})
@@ -353,6 +402,7 @@ func TestHTMLLoadFromAssets(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNil(t, err)
 	expect(t, res.Code, 200)
 	expect(t, res.Header().Get(ContentType), ContentHTML+"; charset=UTF-8")
 	expect(t, res.Body.String(), "head\n<h1>gophers</h1>\n\nfoot\n")

--- a/render_jsonp_test.go
+++ b/render_jsonp_test.go
@@ -15,14 +15,16 @@ type GreetingP struct {
 func TestJSONPBasic(t *testing.T) {
 	render := New()
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.JSONP(w, 299, "helloCallback", GreetingP{"hello", "world"})
+		err = render.JSONP(w, 299, "helloCallback", GreetingP{"hello", "world"})
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNil(t, err)
 	expect(t, res.Code, 299)
 	expect(t, res.Header().Get(ContentType), ContentJSONP+"; charset=UTF-8")
 	expect(t, res.Body.String(), "helloCallback({\"one\":\"hello\",\"two\":\"world\"});")
@@ -33,14 +35,16 @@ func TestJSONPRenderIndented(t *testing.T) {
 		IndentJSON: true,
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.JSONP(w, http.StatusOK, "helloCallback", GreetingP{"hello", "world"})
+		err = render.JSONP(w, http.StatusOK, "helloCallback", GreetingP{"hello", "world"})
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNil(t, err)
 	expect(t, res.Code, http.StatusOK)
 	expect(t, res.Header().Get(ContentType), ContentJSONP+"; charset=UTF-8")
 	expect(t, res.Body.String(), "helloCallback({\n  \"one\": \"hello\",\n  \"two\": \"world\"\n});\n")
@@ -49,13 +53,15 @@ func TestJSONPRenderIndented(t *testing.T) {
 func TestJSONPWithError(t *testing.T) {
 	render := New()
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.JSONP(w, 299, "helloCallback", math.NaN())
+		err = render.JSONP(w, 299, "helloCallback", math.NaN())
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNotNil(t, err)
 	expect(t, res.Code, 500)
 }

--- a/render_test.go
+++ b/render_test.go
@@ -46,3 +46,15 @@ func expect(t *testing.T, a interface{}, b interface{}) {
 		t.Errorf("Expected ||%#v|| (type %v) - Got ||%#v|| (type %v)", b, reflect.TypeOf(b), a, reflect.TypeOf(a))
 	}
 }
+
+func expectNil(t *testing.T, a interface{}) {
+	if a != nil {
+		t.Errorf("Expected ||nil|| - Got ||%#v|| (type %v)", a, reflect.TypeOf(a))
+	}
+}
+
+func expectNotNil(t *testing.T, a interface{}) {
+	if a == nil {
+		t.Errorf("Expected ||not nil|| - Got ||nil|| (type %v)", reflect.TypeOf(a))
+	}
+}

--- a/render_text_test.go
+++ b/render_text_test.go
@@ -11,14 +11,16 @@ func TestTextBasic(t *testing.T) {
 	// nothing here to configure
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.Text(w, 299, "Hello Text!")
+		err = render.Text(w, 299, "Hello Text!")
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNil(t, err)
 	expect(t, res.Code, 299)
 	expect(t, res.Header().Get(ContentType), ContentText+"; charset=UTF-8")
 	expect(t, res.Body.String(), "Hello Text!")
@@ -29,14 +31,16 @@ func TestTextCharset(t *testing.T) {
 		Charset: "foobar",
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.Text(w, 299, "Hello Text!")
+		err = render.Text(w, 299, "Hello Text!")
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNil(t, err)
 	expect(t, res.Code, 299)
 	expect(t, res.Header().Get(ContentType), ContentText+"; charset=foobar")
 	expect(t, res.Body.String(), "Hello Text!")
@@ -47,15 +51,17 @@ func TestTextSuppliedCharset(t *testing.T) {
 		Charset: "foobar",
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set(ContentType, "text/css")
-		render.Text(w, 200, "html{color:red}")
+		err = render.Text(w, 200, "html{color:red}")
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNil(t, err)
 	expect(t, res.Code, 200)
 	expect(t, res.Header().Get(ContentType), "text/css")
 	expect(t, res.Body.String(), "html{color:red}")

--- a/render_xml_test.go
+++ b/render_xml_test.go
@@ -18,14 +18,16 @@ func TestXMLBasic(t *testing.T) {
 	// nothing here to configure
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.XML(w, 299, GreetingXML{One: "hello", Two: "world"})
+		err = render.XML(w, 299, GreetingXML{One: "hello", Two: "world"})
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNil(t, err)
 	expect(t, res.Code, 299)
 	expect(t, res.Header().Get(ContentType), ContentXML+"; charset=UTF-8")
 	expect(t, res.Body.String(), "<greeting one=\"hello\" two=\"world\"></greeting>")
@@ -37,14 +39,16 @@ func TestXMLPrefix(t *testing.T) {
 		PrefixXML: []byte(prefix),
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.XML(w, 300, GreetingXML{One: "hello", Two: "world"})
+		err = render.XML(w, 300, GreetingXML{One: "hello", Two: "world"})
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNil(t, err)
 	expect(t, res.Code, 300)
 	expect(t, res.Header().Get(ContentType), ContentXML+"; charset=UTF-8")
 	expect(t, res.Body.String(), prefix+"<greeting one=\"hello\" two=\"world\"></greeting>")
@@ -55,14 +59,16 @@ func TestXMLIndented(t *testing.T) {
 		IndentXML: true,
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.XML(w, http.StatusOK, GreetingXML{One: "hello", Two: "world"})
+		err = render.XML(w, http.StatusOK, GreetingXML{One: "hello", Two: "world"})
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNil(t, err)
 	expect(t, res.Code, http.StatusOK)
 	expect(t, res.Header().Get(ContentType), ContentXML+"; charset=UTF-8")
 	expect(t, res.Body.String(), "<greeting one=\"hello\" two=\"world\"></greeting>\n")
@@ -73,13 +79,15 @@ func TestXMLWithError(t *testing.T) {
 	// nothing here to configure
 	})
 
+	var err error
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		render.XML(w, 299, map[string]string{"foo": "bar"})
+		err = render.XML(w, 299, map[string]string{"foo": "bar"})
 	})
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/foo", nil)
 	h.ServeHTTP(res, req)
 
+	expectNotNil(t, err)
 	expect(t, res.Code, 500)
 }


### PR DESCRIPTION
Errors are now returned from rendering methods. Existing
applications using this package still compile and behave the
same. I added a new option, DisableHTTPErrorRendering, which,
when set to true, will not render the error and
http.StatusInternalServerError. This option is false by default.

resolves #26