### PR TITLE
EchoHTML function to work with echo v2

### DIFF
--- a/render.go
+++ b/render.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
+	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -351,6 +352,22 @@ func (r *Render) HTML(w http.ResponseWriter, status int, name string, binding in
 	}
 
 	return r.Render(w, h, binding)
+}
+
+func (r *Render) EchoHTML(w io.Writer, name string, binding interface{}, htmlOpt ...HTMLOptions) error {
+	// If we are in development mode, recompile the templates on every HTML request.
+	if r.opt.IsDevelopment {
+		r.compileTemplates()
+	}
+
+	opt := r.prepareHTMLOptions(htmlOpt)
+	// Assign a layout if there is one.
+	if len(opt.Layout) > 0 {
+		r.addLayoutFuncs(name, binding)
+		name = opt.Layout
+	}
+
+	return r.templates.ExecuteTemplate(w, name, binding)
 }
 
 // JSON marshals the given interface object and writes the JSON response.


### PR DESCRIPTION
Expose `EchoHTML` to work with [echo v2 templates](https://labstack.com/echo/guide/templates).

Example:

```go
package main

import (
	"io"

	"github.com/labstack/echo"
	"github.com/labstack/echo/engine/standard"
	"github.com/stereosteve/render"
)

type RenderWrapper struct {
	rend *render.Render
}

func (wrap *RenderWrapper) Render(w io.Writer, name string, data interface{}, c echo.Context) error {
	return wrap.rend.EchoHTML(w, name, data)
}

func main() {
	e := echo.New()
	rw := &RenderWrapper{render.New(render.Options{
		Layout:        "layout",
		IsDevelopment: true,
	})}
	e.SetRenderer(rw)
	e.SetDebug(true)
	e.GET("/", func(c echo.Context) error {
		ctx := map[string]interface{}{
			"day": "Tuesday",
		}
		return c.Render(200, "today", ctx)
	})
	e.Run(standard.New(":1323"))
}
```

This is just a quick hack... there may be a better way to do this.