### PR TITLE
fix potential data race

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -39,3 +39,8 @@ func (bp *BufferPool) Put(b *bytes.Buffer) {
 	default: // Discard the buffer if the pool is full.
 	}
 }
+
+// Initialize buffer pool for writing templates into.
+func init() {
+	bufPool = NewBufferPool(64)
+}

--- a/render.go
+++ b/render.go
@@ -118,11 +118,6 @@ func New(options ...Options) *Render {
 	r.prepareOptions()
 	r.compileTemplates()
 
-	// Create a new buffer pool for writing templates into.
-	if bufPool == nil {
-		bufPool = NewBufferPool(64)
-	}
-
 	return &r
 }
 


### PR DESCRIPTION
Hi, 

I found a data race during my tests.

It is caused by multiple goroutines try to initialize buffer pool at the same time.

How to reproduce?
```sh
git clone https://github.com/overvenus/pd.git
git checkout render-data-race
go test --race ./server/api
```

Error log: 
```
==================
WARNING: DATA RACE
Read by goroutine 55:
  github.com/unrolled/render.New()
      /home/neil/repo/gopath/src/github.com/unrolled/render/render.go:124 +0x383
  github.com/pingcap/pd/server/api.createRouter()
      /home/neil/repo/gopath/src/github.com/pingcap/pd/server/api/router.go:29 +0x1dc
  github.com/pingcap/pd/server/api.ServeHTTP()
      /home/neil/repo/gopath/src/github.com/pingcap/pd/server/api/server.go:34 +0x439

Previous write by goroutine 217:
  github.com/unrolled/render.New()
      /home/neil/repo/gopath/src/github.com/unrolled/render/render.go:125 +0x418
  github.com/pingcap/pd/server/api.createRouter()
      /home/neil/repo/gopath/src/github.com/pingcap/pd/server/api/router.go:29 +0x1dc
  github.com/pingcap/pd/server/api.ServeHTTP()
      /home/neil/repo/gopath/src/github.com/pingcap/pd/server/api/server.go:34 +0x439

Goroutine 55 (running) created at:
  github.com/pingcap/pd/server/api.mustNewCluster.func1()
      /home/neil/repo/gopath/src/github.com/pingcap/pd/server/api/member_test.go:67 +0x146

Goroutine 217 (running) created at:
  github.com/pingcap/pd/server/api.mustNewCluster.func1()
      /home/neil/repo/gopath/src/github.com/pingcap/pd/server/api/member_test.go:67 +0x146
==================
```
