### PR TITLE
Prevent concurrent modification of the template funcmap

### DIFF
--- a/render.go
+++ b/render.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 )
 
 const (
@@ -102,6 +103,7 @@ type Render struct {
 	// Customize Secure with an Options struct.
 	opt             Options
 	templates       *template.Template
+	templatesLk     sync.Mutex
 	compiledCharset string
 }
 
@@ -331,6 +333,9 @@ func (r *Render) Data(w io.Writer, status int, v []byte) error {
 
 // HTML builds up the response from the specified template and bindings.
 func (r *Render) HTML(w io.Writer, status int, name string, binding interface{}, htmlOpt ...HTMLOptions) error {
+	r.templatesLk.Lock()
+	defer r.templatesLk.Unlock()
+
 	// If we are in development mode, recompile the templates on every HTML request.
 	if r.opt.IsDevelopment {
 		r.compileTemplates()


### PR DESCRIPTION
I tried the approach I mentioned previously, using Template.Clone(). It worked, but in the end it was both a more intrusive change and also didn't perform any better. If anything, performance in toy benchmark looked worse than with a mutex. So, mutex it is.