### PR TITLE
Added a comment to point out a typo in an option name

### DIFF
--- a/render.go
+++ b/render.go
@@ -100,6 +100,7 @@ type Options struct {
 	// Disables automatic rendering of http.StatusInternalServerError when an error occurs. Default is false.
 	DisableHTTPErrorRendering bool
 	// Enables using partials without the current filename suffix which allows use of the same template in multiple files. e.g {{ partial "carosuel" }} inside the home template will match carosel-home or carosel.
+	// ***NOTE*** - This option should be named RenderPartialsWithoutSuffix as that is what it does. "Prefix" is a typo. Maintaining the existing name for backwards compatibility.
 	RenderPartialsWithoutPrefix bool
 }
 


### PR DESCRIPTION
Added a comment to explain that RenderPartialsWithoutPrefix should be called RenderPartialsWithoutSuffix.