### PR TITLE
[WIP] Add function to render sub-template with specified binding

### DIFF
--- a/render.go
+++ b/render.go
@@ -322,6 +322,10 @@ func (r *Render) addLayoutFuncs(name string, binding interface{}) {
 			}
 			return "", nil
 		},
+		"template": func(name string, tmplBinding interface{}) (template.HTML, error) {
+			buf, err := r.execute(name, tmplBinding)
+			return template.HTML(buf.String()), err
+		},
 	}
 	if tpl := r.templates.Lookup(name); tpl != nil {
 		tpl.Funcs(funcs)


### PR DESCRIPTION
From within a template, I need the ability to render a shared template and specify the binding based on the current context.

For example...
```
{{range .Items}}<tr><td>{{.Name}}</td><td>{{template "shared/actions" .Actions}}</td></tr>{{end}}
```
... where `Actions` is a property of each `Item` containing a slice of objects that is used to populate an actions dropdown menu.

I added this feature as a new function, `template`.  Another option would be to alter `partial` to optionally accept a binding (by adding a `...interface{}` parameter).  Further, `template` may not be best name if a new function is used.

Since I was unsure about the most appropriate implementation/naming, I thought I'd go ahead and create a PR and then, if you are interested in this feature, make any modifications and add tests once that is done.

Thank you for the library!