### PR TITLE
Remove unnecessary zero value setter

### DIFF
--- a/render.go
+++ b/render.go
@@ -123,9 +123,7 @@ type Render struct {
 // New constructs a new Render instance with the supplied options.
 func New(options ...Options) *Render {
 	var o Options
-	if len(options) == 0 {
-		o = Options{}
-	} else {
+	if len(options) > 0 {
 		o = options[0]
 	}
 


### PR DESCRIPTION
Hey there! Thanks for this package, been using it for quite some time.

This change is fairly inconsequential, but there's no need for these lines, as the value is already at a zero value:

```
var o Options
if len(options) == 0 {
    o = Options{}
}
```

https://play.golang.org/p/vTGrHzyO5nY
