### PR TITLE
chore: migrate to go module.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,11 @@ go:
   - 1.12.x
   - tip
 
+env:
+  - GO111MODULE=on
+
 install:
-  - go get github.com/eknkc/amber
+  - go mod download 
 
 script:
   - go test -v -race -tags=integration

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/unrolled/render
+
+go 1.12
+
+require github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385 h1:clC1lXBpe2kTj2VHdaIu9ajZQe4kcEY9j0NsnDDBZ3o=
+github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=


### PR DESCRIPTION
I propose you to migrate to go module.

With go 1.13 the go modules will be the default.
