### PR TITLE
replace encoding/json with segmentio/encoding

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -2,7 +2,7 @@ package render
 
 import (
 	"bytes"
-	"encoding/json"
+	"github.com/segmentio/encoding/json"
 	"encoding/xml"
 	"html/template"
 	"io"

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/unrolled/render
 
 go 1.12
 
-require github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385
+require (
+	github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385
+	github.com/segmentio/encoding v0.1.3
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385 h1:clC1lXBpe2kTj2VHdaIu9ajZQe4kcEY9j0NsnDDBZ3o=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
+github.com/segmentio/encoding v0.1.3 h1:n3ks4dVnqpc+3iz1wCaSTA8YDi8qBZU2Auv2x8YtZB4=
+github.com/segmentio/encoding v0.1.3/go.mod h1:RWhr02uzMB9gQC1x+MfYxedtmBibb9cZ6Vv9VxRSSbw=

--- a/render_json_test.go
+++ b/render_json_test.go
@@ -1,7 +1,7 @@
 package render
 
 import (
-	"encoding/json"
+	"github.com/segmentio/encoding/json"
 	"math"
 	"net/http"
 	"net/http/httptest"


### PR DESCRIPTION
This PR replaces `encoding/json` with `segmentio/encoding`.
Here are the benchmarks from my own computer:
```
> benchcmp old.txt new.txt
benchmark                     old ns/op     new ns/op     delta
BenchmarkNormalJSON-40        1013          684           -32.48%
BenchmarkStreamingJSON-40     956           686           -28.24%
```