### PR TITLE
Add option to specify file system

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Render comes with a variety of configuration options _(Note: these are not the d
 // ...
 r := render.New(render.Options{
     Directory: "templates", // Specify what path to load the templates from.
+    FileSystem: &LocalFileSystem{}, // Specify filesystem from where files are loaded.
     Asset: func(name string) ([]byte, error) { // Load from an Asset function instead of file.
       return []byte("template content"), nil
     },
@@ -117,6 +118,7 @@ r := render.New()
 
 r := render.New(render.Options{
     Directory: "templates",
+    FileSystem: &LocalFileSystem{},
     Asset: nil,
     AssetNames: nil,
     Layout: "",

--- a/fs.go
+++ b/fs.go
@@ -10,12 +10,12 @@ type FileSystem interface {
 	ReadFile(filename string) ([]byte, error)
 }
 
-type osFileSystem struct{}
+type LocalFileSystem struct{}
 
-func (osFileSystem) Walk(root string, walkFn filepath.WalkFunc) error {
+func (LocalFileSystem) Walk(root string, walkFn filepath.WalkFunc) error {
 	return filepath.Walk(root, walkFn)
 }
 
-func (osFileSystem) ReadFile(filename string) ([]byte, error) {
+func (LocalFileSystem) ReadFile(filename string) ([]byte, error) {
 	return ioutil.ReadFile(filename)
 }

--- a/fs.go
+++ b/fs.go
@@ -1,0 +1,21 @@
+package render
+
+import (
+	"io/ioutil"
+	"path/filepath"
+)
+
+type FileSystem interface {
+	Walk(root string, walkFn filepath.WalkFunc) error
+	ReadFile(filename string) ([]byte, error)
+}
+
+type osFileSystem struct{}
+
+func (osFileSystem) Walk(root string, walkFn filepath.WalkFunc) error {
+	return filepath.Walk(root, walkFn)
+}
+
+func (osFileSystem) ReadFile(filename string) ([]byte, error) {
+	return ioutil.ReadFile(filename)
+}

--- a/render.go
+++ b/render.go
@@ -151,7 +151,7 @@ func (r *Render) prepareOptions() {
 		r.opt.Directory = "templates"
 	}
 	if r.opt.FileSystem == nil {
-		r.opt.FileSystem = &osFileSystem{}
+		r.opt.FileSystem = &LocalFileSystem{}
 	}
 	if len(r.opt.Extensions) == 0 {
 		r.opt.Extensions = []string{".tmpl"}


### PR DESCRIPTION
This option can be used to load files other than the local file system.
For example I'm using it when packing all resources into one binary with [go.rice](https://github.com/GeertJohan/go.rice).

```go
import (
    "github.com/GeertJohan/go.rice"
    "github.com/unrolled/render"
)

// riceBoxFileSystem implements render.FileSystem for rice.Box
// Walk() is already implemented by *rice.Box.
type riceBoxFileSystem struct{ *rice.Box }

func (fs *riceBoxFileSystem) ReadFile(filename string) ([]byte, error) { 
    return fs.Bytes(filename) 
}

fs := &riceBoxFileSystem{rice.MustFindBox("templates")}
render.New(render.Options{
    FileSystem: fs,
})
```