### PR TITLE
Remove buffer pool for HTML render

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -2,9 +2,6 @@ package render
 
 import "bytes"
 
-// bufPool represents a reusable buffer pool for executing templates into.
-var bufPool *BufferPool
-
 // BufferPool implements a pool of bytes.Buffers in the form of a bounded channel.
 // Pulled from the github.com/oxtoacart/bpool package (Apache licensed).
 type BufferPool struct {
@@ -38,9 +35,4 @@ func (bp *BufferPool) Put(b *bytes.Buffer) {
 	case bp.c <- b:
 	default: // Discard the buffer if the pool is full.
 	}
-}
-
-// Initialize buffer pool for writing templates into.
-func init() {
-	bufPool = NewBufferPool(64)
 }

--- a/engine.go
+++ b/engine.go
@@ -82,9 +82,7 @@ func (d Data) Render(w io.Writer, v interface{}) error {
 
 // Render a HTML response.
 func (h HTML) Render(w io.Writer, binding interface{}) error {
-	// Retrieve a buffer from the pool to write to.
-	out := bufPool.Get()
-	err := h.Templates.ExecuteTemplate(out, h.Name, binding)
+	err := h.Templates.ExecuteTemplate(w, h.Name, binding)
 	if err != nil {
 		return err
 	}
@@ -92,10 +90,7 @@ func (h HTML) Render(w io.Writer, binding interface{}) error {
 	if hw, ok := w.(http.ResponseWriter); ok {
 		h.Head.Write(hw)
 	}
-	out.WriteTo(w)
 
-	// Return the buffer to the pool.
-	bufPool.Put(out)
 	return nil
 }
 


### PR DESCRIPTION
`http.ResponseWriter` (the most common `io.Writer` passed to `Render`) is already buffered and this buffer pool simply lead to memory bloat under certain conditions. This work fixes #85. 

As an example of the memory savings here is memory usage on my [Gitea](https://gitea.io) instance before and after this change:

**Before**
![gitea-ram-usage](https://user-images.githubusercontent.com/12156185/114577722-1d124800-9c31-11eb-93c4-41a5996f2a4c.png)

**After**
![gitea-no-bloat](https://user-images.githubusercontent.com/12156185/114577359-c9076380-9c30-11eb-9777-6d09a789dcd1.png)
