### PR TITLE
Improved, configurable buffer pools

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -2,9 +2,6 @@ package render
 
 import "bytes"
 
-// bufPool represents a reusable buffer pool for executing templates into.
-var bufPool *BufferPool
-
 // BufferPool implements a pool of bytes.Buffers in the form of a bounded channel.
 // Pulled from the github.com/oxtoacart/bpool package (Apache licensed).
 type BufferPool struct {
@@ -38,9 +35,4 @@ func (bp *BufferPool) Put(b *bytes.Buffer) {
 	case bp.c <- b:
 	default: // Discard the buffer if the pool is full.
 	}
-}
-
-// Initialize buffer pool for writing templates into.
-func init() {
-	bufPool = NewBufferPool(64)
 }

--- a/genericbufferpool.go
+++ b/genericbufferpool.go
@@ -1,0 +1,9 @@
+package render
+
+import "bytes"
+
+// GenericBufferPool abstracts buffer pool implementations
+type GenericBufferPool interface {
+	Get() *bytes.Buffer
+	Put(*bytes.Buffer)
+}

--- a/sizedbufferpool.go
+++ b/sizedbufferpool.go
@@ -1,0 +1,62 @@
+package render
+
+import (
+	"bytes"
+)
+
+// Pulled from the github.com/oxtoacart/bpool package (Apache licensed).
+
+// SizedBufferPool implements a pool of bytes.Buffers in the form of a bounded
+// channel. Buffers are pre-allocated to the requested size.
+type SizedBufferPool struct {
+	c chan *bytes.Buffer
+	a int
+}
+
+// NewSizedBufferPool creates a new BufferPool bounded to the given size.
+// size defines the number of buffers to be retained in the pool and alloc sets
+// the initial capacity of new buffers to minimize calls to make().
+//
+// The value of alloc should seek to provide a buffer that is representative of
+// most data written to the the buffer (i.e. 95th percentile) without being
+// overly large (which will increase static memory consumption). You may wish to
+// track the capacity of your last N buffers (i.e. using an []int) prior to
+// returning them to the pool as input into calculating a suitable alloc value.
+func NewSizedBufferPool(size int, alloc int) (bp *SizedBufferPool) {
+	return &SizedBufferPool{
+		c: make(chan *bytes.Buffer, size),
+		a: alloc,
+	}
+}
+
+// Get gets a Buffer from the SizedBufferPool, or creates a new one if none are
+// available in the pool. Buffers have a pre-allocated capacity.
+func (bp *SizedBufferPool) Get() (b *bytes.Buffer) {
+	select {
+	case b = <-bp.c:
+		// reuse existing buffer
+	default:
+		// create new buffer
+		b = bytes.NewBuffer(make([]byte, 0, bp.a))
+	}
+	return
+}
+
+// Put returns the given Buffer to the SizedBufferPool.
+func (bp *SizedBufferPool) Put(b *bytes.Buffer) {
+	b.Reset()
+
+	// Release buffers over our maximum capacity and re-create a pre-sized
+	// buffer to replace it.
+	// Note that the cap(b.Bytes()) provides the capacity from the read off-set
+	// only, but as we've called b.Reset() the full capacity of the underlying
+	// byte slice is returned.
+	if cap(b.Bytes()) > bp.a {
+		b = bytes.NewBuffer(make([]byte, 0, bp.a))
+	}
+
+	select {
+	case bp.c <- b:
+	default: // Discard the buffer if the pool is full.
+	}
+}


### PR DESCRIPTION
### Problem

As discussed in #86 and #85, the current buffer pool leads to heap allocations that are 64 * the largest template rendered. This wastes memory. We cannot simply remove the buffer pool though because it is needed to check template errors before writing HTTP status codes.

### Solution

Add a sized buffer pool implementation that garbage collects buffers that grow past a certain point. Use this sized buffer pool by default with some heuristically choosen defaults (I've selected 32 buffers of size 512KiB), but allow users to specify their own if needed. A `GenericBufferPool` interface has been added that allows users to not only modify the `SizedBufferPool` and `BufferPool` implementations, but to implement their own if need be.

### Results

Two benchmarks have been added: `BenchmarkBigHTMLBuffers` and `BenchmarkSmallHTMLBuffers` where the buffer pool buffers are larger and smaller than the rendered template respectively. As expected, the small buffers lead to more allocations and slower HTML templating than the larger buffers.

![benchmark-diff](https://user-images.githubusercontent.com/12156185/114925429-f3e5e900-9de3-11eb-92a8-72bd3638c209.png)

Upon inspecting the memory profiles for each benchmark we see the difference in allocation is precisely where we think it should be: buffers are being allocated upon return to the pool because they've out grown our size limit

**Buffer larger than templates**

![big-buffer-profile](https://user-images.githubusercontent.com/12156185/114925868-8090a700-9de4-11eb-9c6d-3633cfc632d3.png)

**Buffer smaller than templates**

![small-buffer-profile](https://user-images.githubusercontent.com/12156185/114925908-8b4b3c00-9de4-11eb-8f89-901fb087ae4e.png)

