### PR TITLE
Further improve locking (Atomic)

### DIFF
--- a/render.go
+++ b/render.go
@@ -120,9 +120,9 @@ type HTMLOptions struct {
 // Render is a service that provides functions for easily writing JSON, XML,
 // binary data, and HTML templates out to a HTTP Response.
 type Render struct {
+	templateStore atomic.Value
 	// Customize Secure with an Options struct.
 	opt             Options
-	templateStore   atomic.Value
 	compiledCharset string
 }
 


### PR DESCRIPTION
As a second step improving #90, switch from using a RWMutex to use an
atomic.Value and a reconstruct functions to ensure that the current
templates are referenced in the helper func instead of a global
reference.

Close #92 

Signed-off-by: Andrew Thornton <art27@cantab.net>