### PR TITLE
refactor: replace interface{} with any

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -11,7 +11,7 @@ import (
 
 // Engine is the generic interface for all responses.
 type Engine interface {
-	Render(w io.Writer, v interface{}) error
+	Render(w io.Writer, v any) error
 }
 
 // Head defines the basic ContentType and Status fields.
@@ -36,7 +36,7 @@ type HTML struct {
 
 // JSONEncoder is the interface for encoding/json.Encoder.
 type JSONEncoder interface {
-	Encode(v interface{}) error
+	Encode(v any) error
 	SetEscapeHTML(on bool)
 	SetIndent(prefix, indent string)
 }
@@ -77,7 +77,7 @@ func (h Head) Write(w http.ResponseWriter) {
 }
 
 // Render a data response.
-func (d Data) Render(w io.Writer, v interface{}) error {
+func (d Data) Render(w io.Writer, v any) error {
 	if hw, ok := w.(http.ResponseWriter); ok {
 		c := hw.Header().Get(ContentType)
 		if c != "" {
@@ -93,7 +93,7 @@ func (d Data) Render(w io.Writer, v interface{}) error {
 }
 
 // Render a HTML response.
-func (h HTML) Render(w io.Writer, binding interface{}) error {
+func (h HTML) Render(w io.Writer, binding any) error {
 	var buf *bytes.Buffer
 	if h.bp != nil {
 		// If we have a bufferpool, allocate from it
@@ -116,7 +116,7 @@ func (h HTML) Render(w io.Writer, binding interface{}) error {
 }
 
 // Render a JSON response.
-func (j JSON) Render(w io.Writer, v interface{}) error {
+func (j JSON) Render(w io.Writer, v any) error {
 	if j.StreamingJSON {
 		return j.renderStreamingJSON(w, v)
 	}
@@ -154,7 +154,7 @@ func (j JSON) Render(w io.Writer, v interface{}) error {
 	return nil
 }
 
-func (j JSON) renderStreamingJSON(w io.Writer, v interface{}) error {
+func (j JSON) renderStreamingJSON(w io.Writer, v any) error {
 	if hw, ok := w.(http.ResponseWriter); ok {
 		j.Write(hw)
 	}
@@ -174,7 +174,7 @@ func (j JSON) renderStreamingJSON(w io.Writer, v interface{}) error {
 }
 
 // Render a JSONP response.
-func (j JSONP) Render(w io.Writer, v interface{}) error {
+func (j JSONP) Render(w io.Writer, v any) error {
 	var result []byte
 
 	var err error
@@ -207,7 +207,7 @@ func (j JSONP) Render(w io.Writer, v interface{}) error {
 }
 
 // Render a text response.
-func (t Text) Render(w io.Writer, v interface{}) error {
+func (t Text) Render(w io.Writer, v any) error {
 	if hw, ok := w.(http.ResponseWriter); ok {
 		c := hw.Header().Get(ContentType)
 		if c != "" {
@@ -223,7 +223,7 @@ func (t Text) Render(w io.Writer, v interface{}) error {
 }
 
 // Render an XML response.
-func (x XML) Render(w io.Writer, v interface{}) error {
+func (x XML) Render(w io.Writer, v any) error {
 	var result []byte
 
 	var err error

--- a/render.go
+++ b/render.go
@@ -401,13 +401,13 @@ func (r *Render) TemplateLookup(t string) *template.Template {
 	return r.templates.Lookup(t)
 }
 
-func (r *Render) execute(templates *template.Template, name string, binding interface{}) (*bytes.Buffer, error) {
+func (r *Render) execute(templates *template.Template, name string, binding any) (*bytes.Buffer, error) {
 	buf := new(bytes.Buffer)
 
 	return buf, templates.ExecuteTemplate(buf, name, binding)
 }
 
-func (r *Render) layoutFuncs(templates *template.Template, name string, binding interface{}) template.FuncMap {
+func (r *Render) layoutFuncs(templates *template.Template, name string, binding any) template.FuncMap {
 	return template.FuncMap{
 		"yield": func() (template.HTML, error) {
 			buf, err := r.execute(templates, name, binding)
@@ -481,7 +481,7 @@ func (r *Render) prepareHTMLOptions(htmlOpt []HTMLOptions) HTMLOptions {
 }
 
 // Render is the generic function called by XML, JSON, Data, HTML, and can be called by custom implementations.
-func (r *Render) Render(w io.Writer, e Engine, data interface{}) error {
+func (r *Render) Render(w io.Writer, e Engine, data any) error {
 	err := e.Render(w, data)
 	if hw, ok := w.(http.ResponseWriter); err != nil && !r.opt.DisableHTTPErrorRendering && ok {
 		http.Error(hw, err.Error(), http.StatusInternalServerError)
@@ -514,7 +514,7 @@ func (r *Render) Data(w io.Writer, status int, v []byte, opts ...CallOptions) er
 }
 
 // HTML builds up the response from the specified template and bindings.
-func (r *Render) HTML(w io.Writer, status int, name string, binding interface{}, htmlOpt ...HTMLOptions) error {
+func (r *Render) HTML(w io.Writer, status int, name string, binding any, htmlOpt ...HTMLOptions) error {
 	// If we are in development mode, recompile the templates on every HTML request.
 	r.lock.RLock() // rlock here because we're reading the hasWatcher
 	if r.opt.IsDevelopment && !r.hasWatcher {
@@ -559,7 +559,7 @@ func (r *Render) HTML(w io.Writer, status int, name string, binding interface{},
 }
 
 // JSON marshals the given interface object and writes the JSON response.
-func (r *Render) JSON(w io.Writer, status int, v interface{}, opts ...CallOptions) error {
+func (r *Render) JSON(w io.Writer, status int, v any, opts ...CallOptions) error {
 	head := Head{
 		ContentType: resolveContentType(r.opt.JSONContentType+r.compiledCharset, opts),
 		Status:      status,
@@ -578,7 +578,7 @@ func (r *Render) JSON(w io.Writer, status int, v interface{}, opts ...CallOption
 }
 
 // JSONP marshals the given interface object and writes the JSON response.
-func (r *Render) JSONP(w io.Writer, status int, callback string, v interface{}, opts ...CallOptions) error {
+func (r *Render) JSONP(w io.Writer, status int, callback string, v any, opts ...CallOptions) error {
 	head := Head{
 		ContentType: resolveContentType(r.opt.JSONPContentType+r.compiledCharset, opts),
 		Status:      status,
@@ -608,7 +608,7 @@ func (r *Render) Text(w io.Writer, status int, v string, opts ...CallOptions) er
 }
 
 // XML marshals the given interface object and writes the XML response.
-func (r *Render) XML(w io.Writer, status int, v interface{}, opts ...CallOptions) error {
+func (r *Render) XML(w io.Writer, status int, v any, opts ...CallOptions) error {
 	head := Head{
 		ContentType: resolveContentType(r.opt.XMLContentType+r.compiledCharset, opts),
 		Status:      status,

--- a/render_json_test.go
+++ b/render_json_test.go
@@ -18,7 +18,7 @@ type TestEncoder struct {
 	w io.Writer
 }
 
-func (e TestEncoder) Encode(_ interface{}) error {
+func (e TestEncoder) Encode(_ any) error {
 	_, _ = e.w.Write([]byte(e.String()))
 
 	return nil

--- a/render_test.go
+++ b/render_test.go
@@ -93,7 +93,7 @@ func BenchmarkHTML(b *testing.B) {
 }
 
 // Test Helpers.
-func expect(t *testing.T, a interface{}, b interface{}) {
+func expect(t *testing.T, a any, b any) {
 	t.Helper()
 
 	if a != b {
@@ -101,7 +101,7 @@ func expect(t *testing.T, a interface{}, b interface{}) {
 	}
 }
 
-func expectNil(t *testing.T, a interface{}) {
+func expectNil(t *testing.T, a any) {
 	t.Helper()
 
 	if a != nil {
@@ -109,7 +109,7 @@ func expectNil(t *testing.T, a interface{}) {
 	}
 }
 
-func expectNotNil(t *testing.T, a interface{}) {
+func expectNotNil(t *testing.T, a any) {
 	t.Helper()
 
 	if a == nil {


### PR DESCRIPTION
Replace `interface{}` with `any` across the codebase. `any` is a type alias for `interface{}` available since Go 1.18. The module already requires go 1.25.0, so `any` is the preferred form.

This change is fully backward compatible — `any` and `interface{}` are identical at runtime.